### PR TITLE
Fix slot var being used before its decralar

### DIFF
--- a/src/lgraphcanvas.js
+++ b/src/lgraphcanvas.js
@@ -9055,13 +9055,13 @@ export class LGraphCanvas {
                 if (LiteGraph.canSetSlotsLabels) {
                     menu_info.push({ content: "Set Label", slot: slot });
                 }
+                var _slot = slot.input || slot.output;
                 if (_slot.nameLocked===false || LiteGraph.canRenameSlots) {
                     menu_info.push({ content: "Rename Slot", slot: slot });
                 }
                 if (slot?.output?.links?.length || slot.input?.link) {
                     menu_info.push({ content: "Disconnect Links", slot: slot });
                 }
-                var _slot = slot.input || slot.output;
                 if (_slot.removable || LiteGraph.canRemoveSlots) {
                     menu_info.push(_slot.locked
                         ? "Cannot remove"


### PR DESCRIPTION
_slot is used before its declaration.
Tho, I think there is more things to fix up in other commits, as there is no _slot.nameLocked property